### PR TITLE
Fixed forgot password icon

### DIFF
--- a/angular-src/src/app/components/forgot-password/forgot-password.component.html
+++ b/angular-src/src/app/components/forgot-password/forgot-password.component.html
@@ -5,7 +5,7 @@
     </div>
     <form class="forgot-password-container-child">
         <div class="form-group">
-          <img src="./../../../assets/img/public-icons/black-envelope-64.png" alt="envelope icon">
+          <img src="./../../../assets/img/contact/black-envelope-64.png" alt="envelope icon">
           <input type="email" class="form-control" id="exampleInputEmail1" aria-describedby="emailHelp" placeholder="Enter email">
           <button class="btn btn-secondary">Submit</button>
         </div>


### PR DESCRIPTION
Fixed the pathing to the `forgot-password` component from `public-icons` to `contact`.