### PR TITLE
Content security policy

### DIFF
--- a/ShowOffAPI/package.json
+++ b/ShowOffAPI/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",
+    "cookie-session": "^2.0.0-beta.3",
     "dotenv": "^5.0.1",
     "express": "^4.16.2",
     "helmet": "^3.12.0",

--- a/ShowOffAPI/package.json
+++ b/ShowOffAPI/package.json
@@ -29,6 +29,7 @@
     "bcryptjs": "^2.4.3",
     "dotenv": "^5.0.1",
     "express": "^4.16.2",
+    "helmet": "^3.12.0",
     "jsonwebtoken": "^8.2.0",
     "mongoose": "^4.13.6",
     "mongoose-version": "^1.1.0"

--- a/ShowOffAPI/server.js
+++ b/ShowOffAPI/server.js
@@ -5,6 +5,7 @@ const mongoose = require('mongoose');
 const config = require('./config');
 const helmet = require('helmet');
 const bodyParser = require('body-parser');
+const cookieSession = require('cookie-session');
 require('dotenv').config();
 app.disable('x-powered-by');
 
@@ -19,6 +20,15 @@ const port = process.env.PORT || 8100;
 
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
+
+// cookie-session middleware to enable cookies that will eventually hold login info
+app.use(cookieSession({
+  name: 'session',
+  keys: [ process.env.COOKIESECRET ],
+ 
+  // Cookie Options
+  maxAge: 2 * 60 * 60 * 1000 // 2 hours
+}))
 
 // CONNECT TO DATABASE
 mongoose.connect(config.database, { useMongoClient: true});
@@ -40,7 +50,7 @@ app.use( function( req, res, next ) {
        res.setHeader('Access-Control-Allow-Origin', origin);
   }
   // res.header( "Access-Control-Allow-Origin", "http://192.168.99.100:4200, http://localhost:4200" );
-  res.header( "Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept, Authorization, X-XSRF-TOKEN, JR-Token, Content-Security-Policy, X-Frame-Options" );
+  res.header( "Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept, Authorization, X-XSRF-TOKEN, Content-Security-Policy, X-Frame-Options" );
   res.header( "Access-Control-Allow-Methods", "GET,POST,PUT,DELETE" );
   res.header( "Content-Security-Policy", "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self';" );
   res.header( "X-Frame-Options", "DENY");
@@ -61,7 +71,8 @@ app.use( function( req, res, next ) {
 // API ROUTING
 // middleware to use for all requests
 app.use(function (req, res, next) {
-  console.log('using router');
+  console.log('API hit');
+  console.log('cookie test?: ', req.session);
   next();
 });
 

--- a/ShowOffAPI/server.js
+++ b/ShowOffAPI/server.js
@@ -3,8 +3,10 @@ const router = express.Router();
 const app = express();
 const mongoose = require('mongoose');
 const config = require('./config');
+const helmet = require('helmet');
 const bodyParser = require('body-parser');
 require('dotenv').config();
+app.disable('x-powered-by');
 
 // test env
 console.log('env test', process.env.TEST);
@@ -38,8 +40,9 @@ app.use( function( req, res, next ) {
        res.setHeader('Access-Control-Allow-Origin', origin);
   }
   // res.header( "Access-Control-Allow-Origin", "http://192.168.99.100:4200, http://localhost:4200" );
-  res.header( "Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept, Authorization, X-XSRF-TOKEN, JR-Token" );
-  res.header( "Access-Control-Allow-Methods", "GET,POST,PUT,DELETE" )
+  res.header( "Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept, Authorization, X-XSRF-TOKEN, JR-Token, Content-Security-Policy" );
+  res.header( "Access-Control-Allow-Methods", "GET,POST,PUT,DELETE" );
+  res.header( "Content-Security-Policy", "")
   next();
 } );
 

--- a/ShowOffAPI/server.js
+++ b/ShowOffAPI/server.js
@@ -40,9 +40,10 @@ app.use( function( req, res, next ) {
        res.setHeader('Access-Control-Allow-Origin', origin);
   }
   // res.header( "Access-Control-Allow-Origin", "http://192.168.99.100:4200, http://localhost:4200" );
-  res.header( "Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept, Authorization, X-XSRF-TOKEN, JR-Token, Content-Security-Policy" );
+  res.header( "Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept, Authorization, X-XSRF-TOKEN, JR-Token, Content-Security-Policy, X-Frame-Options" );
   res.header( "Access-Control-Allow-Methods", "GET,POST,PUT,DELETE" );
-  res.header( "Content-Security-Policy", "")
+  res.header( "Content-Security-Policy", "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self';" );
+  res.header( "X-Frame-Options", "DENY");
   next();
 } );
 

--- a/angular-src/src/app/app.module.ts
+++ b/angular-src/src/app/app.module.ts
@@ -2,6 +2,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { RoutingComponents, RoutingModule } from './app.routing.module';
 import { HttpModule } from '@angular/http';
+import { HttpClientModule } from '@angular/common/http';
 
 import { AppComponent } from './app.component';
 import {  ReactiveFormsModule, FormsModule } from '@angular/forms';
@@ -21,7 +22,7 @@ import { CanActivateRouteGuard } from './services/can-activate-route.guard';
   imports: [
     BrowserModule, RoutingModule,
     FormsModule, HttpModule,
-    ReactiveFormsModule
+    ReactiveFormsModule, HttpClientModule
   ],
 
   providers: [ JRLoginService, JRPortfolioService, CanActivateRouteGuard ],

--- a/angular-src/src/app/components/login-page/login-page.component.ts
+++ b/angular-src/src/app/components/login-page/login-page.component.ts
@@ -37,12 +37,12 @@ export class LoginPageComponent implements OnInit {
     const savedPassword = this.form.value.password;
 
     this._jr.loginPost(savedUsername, savedPassword).subscribe(result => {
-      console.log(result.json());
-      if (result.json().status === 1) {
+      console.log(result);
+      if (result['status'] === 1) {
         console.log("Success");
-        console.log("Token:", result.json().token);
+        console.log("Token:", result['token']);
         this.router.navigate(["/dashboard"]);
-        this._jr.storeAuth(savedUsername, result.json().id, result.json().token);
+        this._jr.storeAuth(savedUsername, result['id'], result['token']);
       } else {
         console.log("nope");
       }

--- a/angular-src/src/app/services/jr-login-service.ts
+++ b/angular-src/src/app/services/jr-login-service.ts
@@ -3,6 +3,9 @@ import { Http, Headers, RequestOptions } from '@angular/http';
 import { Router, CanActivate } from '@angular/router';
 import { stringify } from '@angular/compiler/src/util';
 import { environment } from './../../environments/environment';
+import { HttpClient } from '@angular/common/http';
+import { HttpHeaders } from '@angular/common/http';
+
 
 @Injectable()
 
@@ -22,7 +25,7 @@ export class JRLoginService {
         token: null
     };
 
-    constructor(private _http: Http, private router: Router) {
+    constructor(private _http: Http, private _httpClient: HttpClient, private router: Router) {
 
     }
 
@@ -47,14 +50,31 @@ export class JRLoginService {
         return JSON.parse(localStorage.getItem('loggedInUser'));
     }
 
+    // This is using the old angular http module
+    // TODO: Rewrite all other functions using old http module to newer one
+    // loginPostOld(username: String, password: String) {
+    //     const body = {
+    //         Username: username,
+    //         Password: password
+    //     };
+    //     const headers = new Headers({'Content-Type': 'application/json'});
+    //     const options = new RequestOptions({headers: headers});
+    //     return this._http.post(this._URL + 'api-new/registration/login', body , options);
+    // }
+
     loginPost(username: String, password: String) {
         const body = {
             Username: username,
             Password: password
         };
-        const headers = new Headers({'Content-Type': 'application/json'});
-        const options = new RequestOptions({headers: headers});
-        return this._http.post(this._URL + 'api-new/registration/login', body , options);
+
+        const HttpOptions = {
+            headers: new HttpHeaders({
+                'Content-Type': 'application/json'
+            })
+        };
+
+        return this._httpClient.post(this._URL + 'api-new/registration/login', body, HttpOptions);
     }
 
     logoutUser() {


### PR DESCRIPTION
Some security stuffs:

Implemented content-security-policy (CSP) on the API end. This tacks on a custom header that is supposed to declare what origins are allowed to run scripts/styles/etc. Unfortunately, since this inside the API which is not hosting the front end (thats in another container), it's not actually stopping anything. So... bummer.

Removed X-powered-by header from API
Installed cookie-session to prepare for handling cookies should I have the time to move the token from local storage to the cookie.
I read that using the HttpClient angular module is more safe than the Http angular module that I used. Double bummer. I rewrote the login service function to utilize the newer client. Eventually, I will have to modify each Http call which will kinda suck, but ya gotta do what ya gotta do.

These extra packages will require a new build of the API server inside docker. 
:building_construction: 